### PR TITLE
dockerize, update README formatting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+README.md
+Dockerfile
+docker-compose.yml
+.git
+Injecting SQLite database based application.pdf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:7.0-apache
+MAINTAINER jose nazario <jose@monkey.org>
+LABEL version="1.0" description="sqlite-lab Docker image"
+
+RUN apt-get update && \
+    apt-get install -y php5-sqlite && \
+	mkdir /var/www/html/sqlite-lab
+
+COPY . /var/www/html/sqlite-lab

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Types of SQL Injection in this Lab
 
 3. Boolean based Blind SQL Injection 
 
-#Guide for learning SQLIte SQL Injection 
+# Guide for learning SQLIte SQL Injection 
 
 https://github.com/incredibleindishell/sqlite-lab/blob/master/Injecting%20SQLite%20database%20based%20application.pdf
 
-#Note: -
+# Note: -
 
 Those users who are using ubuntu, make sure php-sqlite package is installed in system
 
@@ -25,7 +25,7 @@ command to install php-sqlite package
 
 apt-get install php5-sqlite
 
-#Lab screenshot
+# Lab screenshot
 
 
 screenshot 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.1'
+
+services:
+  web:
+    image: sqlite-lab
+    hostname: sqliteweb
+    build:
+      context: .
+    ports:
+      - "8080:80"


### PR DESCRIPTION
this patch adds a Dockerfile that enables users to launch the lab in a container.

installation:

1. install docker https://docs.docker.com/engine/installation/ .. optionally also install docker-compose: https://docs.docker.com/compose/install/ 
2. docker-compose up

you're now up and running and can browse it at http://localhost:8080/sqlite-lab/. this enables you to cut and paste examples from the tutorial and only have to change the port. 