### PR TITLE
Removed unavailable php-sqlite package from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM php:7.0-apache
+FROM php:8.1-apache-bullseye
 MAINTAINER jose nazario <jose@monkey.org>
-LABEL version="1.0" description="sqlite-lab Docker image"
+LABEL version="1.1" description="sqlite-lab Docker image"
 
 RUN apt-get update && \
-    apt-get install -y php5-sqlite && \
-	mkdir /var/www/html/sqlite-lab
+    mkdir /var/www/html/sqlite-lab
 
 COPY . /var/www/html/sqlite-lab


### PR DESCRIPTION
Building the Dockerfile fails.
The php-sqlite package is now compiled into the php docker container hence not available for installation.

Removed the corresponding line in Dockerfile and bumped up the PHP version to 8.1